### PR TITLE
feat: use mounts for generated-styles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 # Description: Dockerfile for the Helsinki tileserver-gl image
-# Build: docker build -t helsinki/tileserver-gl:latest .
-# Run: docker run --rm -it -v /local/data/mbtiles:/data/mbtiles -p 8080:8080 helsinki/tileserver-gl:latest
+# See README.md for build and running instructions
 
-# local development base image path
-# FROM maptiler/tileserver-gl:v5.1.3
-FROM container-registry.platta-net.hel.fi/devops/maptiler/tileserver-gl:v5.1.3
-
+ARG BUILDER_REGISTRY=docker.io
+FROM ${BUILDER_REGISTRY}/maptiler/tileserver-gl:v5.1.3
 USER root:root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -16,13 +13,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV SOURCES_OPENMAPTILES_URL "mbtiles://helsinki.mbtiles"
-ENV GLYPHS_URL "{fontstack}/{range}.pbf"
+# These ENVs are used by the init container that generates the styles in openshift
+ENV SOURCES_OPENMAPTILES_URL="mbtiles://helsinki.mbtiles"
+ENV GLYPHS_URL="{fontstack}/{range}.pbf"
 
-RUN mkdir /generate-styles && chown node:0 /generate-styles
-ADD docker-entrypoint.sh /generate-styles
-ADD generate-styles.sh /generate-styles
-ADD templates /generate-styles/templates
+ADD generate-styles.sh /styles/
+ADD templates /styles/templates
 ADD fonts /data/fonts
 ADD mbtiles /data/mbtiles
 ADD sprites /data/sprites
@@ -34,5 +30,3 @@ USER node:node
 # Setting group to 0 makes the environment similar to Openshift
 # wrt. filesystem permissions. Openshift runs everything with group 0
 USER node:0
-
-ENTRYPOINT ["/generate-styles/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -10,18 +10,27 @@ Build:
 
 `docker build -t helsinki/tileserver-gl:latest .`
 
+## Generate styles
+
+```bash
+source .env-example
+./generate-styles.sh
+```
+
+
 ## Run with platta hosted mbtiles
 
-`docker run --rm -it -e SOURCES_OPENMAPTILES_URL=https://helsinki-maptiles.dev.hel.ninja/data/helsinki.json -p 8080:8080 helsinki/tileserver-gl:latest`
+```bash
+docker run --rm -it -v "./generated-styles:/data/generated-styles" -p 8080:8080 helsinki/tileserver-gl:latest
+```
 
 ## Run with local mbtiles
 
 If you have `/local/data/mbtiles/helsinki.mbtiles` then
 
-`docker run --rm -it -v /local/data/mbtiles:/data/mbtiles -p 8080:8080 helsinki/tileserver-gl:latest`
-
-`SOURCES_OPENMAPTILES_URL` defaults to `mbtiles://helsinki.mbtiles`. Override as needed using `-e`
-
+```bash
+docker run --rm -it -v "./generated-styles:/data/generated-styles" -v /local/data/mbtiles:/data/mbtiles -p 8080:8080 helsinki/tileserver-gl:latest
+```
 
 ## Contributing
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-cd /generate-styles
-mkdir generated-styles
-./generate-styles.sh
-mv ./generated-styles /data/generated-styles
-cd /data
-exec /usr/src/app/docker-entrypoint.sh


### PR DESCRIPTION
This simplifies the permission handling issues, but slightly complicates local setup.

Locally we can just mount the local generated-styles directory.

In openshift we can use an init container to generate the styles in an emptyDir and then mount that emptyDir as read only inside /data